### PR TITLE
Add ability to target ^/~ semver versions for dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,8 @@ inquirer.registerPrompt(
   require("inquirer-autocomplete-prompt")
 );
 
+inquirer.registerPrompt("semverList", require("./prompts/semverList"));
+
 module.exports = async ({ input, flags }) => {
   const { resolve } = path;
   const projectDir = input.shift() || ".";
@@ -256,7 +258,7 @@ module.exports = async ({ input, flags }) => {
 
   const { targetVersion } = await inquirer.prompt([
     {
-      type: "list",
+      type: "semverList",
       name: "targetVersion",
       message: "Select version to install:",
       pageSize: 10,

--- a/src/prompts/semverList.js
+++ b/src/prompts/semverList.js
@@ -1,0 +1,111 @@
+const Base = require("inquirer/lib/prompts/base");
+const observe = require("inquirer/lib/utils/events");
+const Paginator = require("inquirer/lib/utils/paginator");
+const cliCursor = require("cli-cursor");
+const chalk = require("chalk");
+
+const cycle = (length, currentIndex, backwards) =>
+  backwards
+    ? currentIndex - 1 < 0
+      ? length - 1
+      : currentIndex - 1
+    : currentIndex + 1 >= length
+      ? 0
+      : currentIndex + 1;
+
+module.exports = class SemverListPrompt extends Base {
+  _run(cb) {
+    this.done = cb;
+    this.prefixes = ["~", "", "^"];
+    this.selectedIndex = 0;
+    this.semverPrefix = null;
+    this.paginator = new Paginator(this.screen);
+
+    cliCursor.hide();
+
+    const events = observe(this.rl);
+
+    events.line.subscribe(this.onSubmit.bind(this));
+    events.keypress.subscribe(({ key, key: { name: keyName } }) => {
+      switch (keyName) {
+        case "up":
+        case "down":
+          this.selectedIndex = cycle(
+            this.opt.choices.length,
+            this.selectedIndex,
+            keyName === "up"
+          );
+          this.semverPrefix = null;
+          return this.render();
+        case "left":
+        case "right":
+          this.semverPrefix = this.prefixes[
+            cycle(
+              this.prefixes.length,
+              this.prefixes.indexOf(this.getSemverPrefix()),
+              keyName === "left"
+            )
+          ];
+          return this.render();
+      }
+    });
+
+    this.render();
+  }
+
+  getSemverPrefix(value = this.getValue()) {
+    return this.prefixes.includes(value.charAt(0)) ? value.charAt(0) : "";
+  }
+
+  getValue(choice = this.opt.choices.getChoice(this.selectedIndex)) {
+    if (this.semverPrefix === null) return choice.value;
+
+    if (this.getSemverPrefix(choice.value)) {
+      return `${this.semverPrefix}${choice.value.substr(1)}`;
+    } else {
+      return `${this.semverPrefix}${choice.value}`;
+    }
+  }
+
+  getName(choice = this.opt.choices.getChoice(this.selectedIndex)) {
+    if (this.semverPrefix === null) return choice.name;
+
+    if (this.getSemverPrefix(choice.value)) {
+      return `${this.semverPrefix}${choice.name.substr(1)}`;
+    } else {
+      return `${this.semverPrefix}${choice.name}`;
+    }
+  }
+
+  onSubmit() {
+    this.screen.render(
+      `\nSelected version: ${chalk.white.bold(this.getValue())}\n`
+    );
+    cliCursor.show();
+    this.screen.done();
+    this.done(this.getValue());
+  }
+
+  render() {
+    let output = this.getQuestion();
+    output += chalk`\n  {bold.yellow TIP:} Move {yellow LEFT} and {yellow RIGHT} to change semver-prefix: ~ or ^\n\n`;
+
+    let lines = [];
+    this.opt.choices.forEach((choice, idx) => {
+      const line =
+        this.selectedIndex === idx
+          ? chalk.cyan(`❯ ${this.getName(choice)}`)
+          : `  ${choice.name}`;
+
+      lines = [...lines, line];
+    });
+
+    output += this.paginator.paginate(
+      lines.join("\n"),
+      this.selectedIndex,
+      this.opt.pageSize
+    );
+
+    this.screen.render(output);
+  }
+};

--- a/test/dedupe.flag.spec.js
+++ b/test/dedupe.flag.spec.js
@@ -64,7 +64,7 @@ describe("--dedupe flag", () => {
 
         >>> input ENTER
 
-        ? Select version to install: (Use arrow keys)
+        ? Select version to install:
 
         >>> input ARROW_DOWN
         >>> input ENTER

--- a/test/lerna.json.packages.spec.js
+++ b/test/lerna.json.packages.spec.js
@@ -55,7 +55,7 @@ describe("lerna.json `packages` configuration", () => {
 
         >>> input ENTER
 
-        ? Select version to install: (Use arrow keys)
+        ? Select version to install:
 
         >>> input ARROW_UP
         >>> input ENTER
@@ -120,7 +120,7 @@ describe("lerna.json `packages` configuration", () => {
          >>> input SPACE
          >>> input ENTER
 
-         ? Select version to install: (Use arrow keys)
+         ? Select version to install:
 
          >>> input ARROW_UP
          >>> input ENTER

--- a/test/semver.choice.dep.spec.js
+++ b/test/semver.choice.dep.spec.js
@@ -1,0 +1,109 @@
+const { default: runProgram } = require("./utils/runProgram");
+const generateProject = require("./utils/generateProject");
+const { resolve } = require("path");
+const expect = require("unexpected");
+
+describe("Setting semver prefix for dependency", async () => {
+  it("correctly toggles through prefixes using left/right arrow keys", async () => {
+    // eslint-disable-next-line
+    jest.setTimeout(100000);
+    const projectPath = await generateProject({
+      name: "project-a",
+      packages: [
+        { name: "sub-package-a" },
+        {
+          name: "sub-package-b",
+          dependencies: { treediff: "0.1.0" },
+        },
+        { name: "sub-package-c" },
+        { name: "sub-package-d", dependencies: { lodash: "~0.2.0" } },
+      ],
+    });
+
+    await runProgram(
+      projectPath,
+      `
+        ? Select a dependency to upgrade: (Use arrow keys or type to search)
+        ❯ lodash (1 version)
+          treediff (1 version)
+
+        >>> input lodash
+
+        ? Select a dependency to upgrade: lodash
+        ❯ lodash (1 version)
+
+        >>> input ENTER
+
+        ❯◯ sub-package-a
+         ◯ sub-package-b
+         ◯ sub-package-c
+         ◉ sub-package-d (~0.2.0)
+
+        >>> input ARROW_DOWN
+        >>> input ARROW_DOWN
+        >>> input ARROW_DOWN
+
+        >>> input ENTER
+
+        ? Select version to install:
+
+        >>> input ARROW_UP
+        >>> input ARROW_UP
+
+        ❯ 0.2.0
+          0.1.0
+
+        >>> input ARROW_RIGHT
+
+        ❯ ^0.2.0
+          0.1.0
+
+        >>> input ARROW_RIGHT
+
+        ❯ ~0.2.0
+          0.1.0
+
+        >>> input ARROW_RIGHT
+
+        ❯ 0.2.0
+          0.1.0
+
+        >>> input ARROW_LEFT
+
+        ❯ ~0.2.0
+          0.1.0
+
+        >>> input ARROW_LEFT
+
+        ❯ ^0.2.0
+          0.1.0
+
+        >>> input ARROW_LEFT
+
+        ❯ 0.2.0
+          0.1.0
+
+        >>> input ARROW_RIGHT
+
+        ❯ ^0.2.0
+          0.1.0
+
+        >>> input ENTER
+
+        ? Do you want to create a new git branch for the change? (Y/n)
+
+        >>> input CTRL+C
+       `
+    );
+
+    expect(
+      require(resolve(projectPath, "packages/sub-package-d/package.json")),
+      "to satisfy",
+      {
+        dependencies: {
+          lodash: "^0.2.2",
+        },
+      }
+    );
+  });
+});

--- a/test/update.dep.spec.js
+++ b/test/update.dep.spec.js
@@ -53,7 +53,7 @@ describe("Update dependency", async () => {
 
         >>> input ENTER
 
-        ? Select version to install: (Use arrow keys)
+        ? Select version to install:
 
         >>> input ARROW_UP
         >>> input ARROW_UP
@@ -124,7 +124,7 @@ describe("Update dependency", async () => {
 
         >>> input ENTER
 
-        ? Select version to install: (Use arrow keys)
+        ? Select version to install:
 
         >>> input ARROW_UP
         >>> input ARROW_UP


### PR DESCRIPTION
With left/right arrow keys

![semver](https://user-images.githubusercontent.com/6997051/49304794-a8aa3480-f4cd-11e8-86a7-978996686ee5.gif)

Reference: https://github.com/Anifacted/lerna-update-wizard/issues/27