### PR TITLE
Add scoped dependency support in noninteractive mode

### DIFF
--- a/src/utils/parseDependency.js
+++ b/src/utils/parseDependency.js
@@ -1,5 +1,17 @@
 module.exports = signature => {
-  const [name, version] = signature.split("@");
+  const firstIndex = signature.indexOf("@");
+  const lastIndex = signature.lastIndexOf("@");
+
+  let name;
+  let version;
+  if (firstIndex !== lastIndex) {
+    name = signature.substring(0, lastIndex);
+    version = signature.substring(lastIndex + 1);  
+  } else if (firstIndex > 0) {
+    [name, version] = signature.split("@");
+  } else {
+    name = signature;
+  }
 
   return { name, version };
 };

--- a/test/noninteractive.spec.js
+++ b/test/noninteractive.spec.js
@@ -111,4 +111,33 @@ describe("Noninteractive mode", () => {
       );
     });
   });
+
+  describe("when updating existing scoped dependency", () => {
+    it("should install package", async () => {
+      const projectPath = await generateProject({
+        name: "project-noninteractive-updating-scoped-dependency",
+        packages: [
+          {
+            name: "sub-package",
+            dependencies: {
+              "@ngrx/entity": "6.1.0",
+            },
+          },
+        ],
+      });
+
+      await runProgram(projectPath, `Installed 1 packages in`, {
+        flags: "--non-interactive --dependency @ngrx/entity@7.0.0",
+      });
+
+      expect(
+        require(resolve(
+          projectPath,
+          "packages/sub-package/node_modules/@ngrx/entity/package.json"
+        )),
+        "to satisfy",
+        { version: "7.0.0" }
+      );
+    });
+  });
 });


### PR DESCRIPTION
Add the ability to update scoped dependencies in non-interactive mode (e.g. @angular/core@7.2.0, @nrgx/entity@7.0.0, etc.)