### PR TITLE
Stop formatting package.json files with `prettier-package-json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lodash": "^4.17.4",
     "meow": "^4.0.0",
     "minimist": "^1.2.0",
-    "prettier-package-json": "^2.1.0",
     "semver-compare": "^1.0.0"
   },
   "devDependencies": {

--- a/src/utils/modifyPackageJson.js
+++ b/src/utils/modifyPackageJson.js
@@ -1,7 +1,20 @@
-const { format } = require("prettier-package-json");
 const merge = require("lodash/merge");
+const sortBy = require("lodash/sortBy");
+const fromPairs = require("lodash/fromPairs");
+
+const sortByKeys = object =>
+  fromPairs(sortBy(Object.keys(object)).map(key => [key, object[key]]));
 
 module.exports = (basePackageJson, modificationsBlob) => {
   const merged = merge(basePackageJson, modificationsBlob);
-  return format(merged);
+
+  merged.dependencies = merged.dependencies && sortByKeys(merged.dependencies);
+
+  merged.devDependencies =
+    merged.devDependencies && sortByKeys(merged.devDependencies);
+
+  merged.peerDependencies =
+    merged.peerDependencies && sortByKeys(merged.peerDependencies);
+
+  return JSON.stringify(merged, null, 2);
 };

--- a/src/utils/modifyPackageJson.spec.js
+++ b/src/utils/modifyPackageJson.spec.js
@@ -48,34 +48,34 @@ describe("modifyPackageJson", () => {
       "to equal",
       `{
   "name": "lerna-update-wizard",
+  "bin": {
+    "lernaupdate": "./bin/lernaupdate"
+  },
+  "version": "0.12.0",
+  "main": "index.js",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/Anifacted/lerna-update-wizard"
-  },
-  "version": "0.12.0",
-  "main": "index.js",
-  "bin": {
-    "lernaupdate": "./bin/lernaupdate"
-  },
-  "scripts": {
-    "test": "jest --verbose --runInBand"
   },
   "dependencies": {
     "chalk": "^2.3.0",
     "d3": "3",
     "semver-compare": "^1.0.0"
   },
-  "peerDependencies": {
-    "underscore": "~2"
-  },
   "devDependencies": {
     "lodash": "3"
   },
+  "scripts": {
+    "test": "jest --verbose --runInBand"
+  },
   "jest": {
     "testURL": "http://localhost"
+  },
+  "peerDependencies": {
+    "underscore": "~2"
   }
-}\n`
+}`
     );
   });
 });


### PR DESCRIPTION
This will mean that only the keys `dependencies`, `devDependencies` and `peerDependencies` are sorted in the package.json.