### PR TITLE
fix: missing dependency on fs-extra

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "inquirer-autocomplete-prompt": "^0.12.1",
     "lodash": "^4.17.4",
     "meow": "^4.0.0",
+    "fs-extra": "^7.0.0",    
     "minimist": "^1.2.0",
     "semver-compare": "^1.0.0"
   },
@@ -29,7 +30,6 @@
     "@rauschma/stringio": "^1.4.0",
     "eslint": "^4.14.0",
     "eslint-config-pretty-standard": "^1.1.0",
-    "fs-extra": "^7.0.0",
     "jest": "^23.4.2",
     "node-publisher": "^1.4.0",
     "prettier": "^1.9.2",


### PR DESCRIPTION
Move `fs-extra` from `devDependencies` to `dependencies` since runJob.js depends on it:

https://github.com/Anifacted/lerna-update-wizard/blob/84720b54ed7295e1cca3ff21d9af8bf007d4bcae/src/runJob.js#L1