### PR TITLE
Check for errors in NPM output and reject command

### DIFF
--- a/src/utils/runCommand.js
+++ b/src/utils/runCommand.js
@@ -11,10 +11,16 @@ module.exports = async (cmd, options = {}) => {
   if (options.logTime) perf.start();
 
   let data = "";
+  let err = "";
   return new Promise((resolve, reject) => {
     proc.stdout.on("data", d => (data = data + d.toString()));
     proc.stdout.on("end", () => {
       ui.logBottom("");
+
+      // Check for errors in npm stderr output
+      if (/^npm ERR!/m.test(err)) {
+        return reject(err);
+      }
 
       if (options.endMessage || options.logTime) {
         const timeLog = options.logTime ? `(${perf.stop().words})` : "";
@@ -28,5 +34,6 @@ module.exports = async (cmd, options = {}) => {
       resolve(data);
     });
     proc.stdout.on("error", reject);
+    proc.stderr.on("data", data => (err += data.toString()));
   });
 };


### PR DESCRIPTION
Added some code to check for NPM errors when running a command and reject the promise. (see #49)
From the outside, `lernaupdate` seemed to be working happily, however there was a permission error in one of my packages that was resulting in an npm error. There was no way to tell that error was happening. I only noticed when I went to commit the updated `package.json` and noticed there were no changes.

Example of the output:
![image](https://user-images.githubusercontent.com/5100175/85205619-78fa9180-b2ea-11ea-93c3-9d2bd27f0a2a.png)
(had to redact the output a little for... reasons)

I think there are a few caveats:
- This is NPM specific. I don't use Yarn so we would probably need to update the regex to support Yarn errors?
- NPM outputs to `stderr` info that is not an error (warnings and such) so I made sure the output contained at least one `npm ERR!` pattern. This is _probably_ ok but kind of fragile. I can't think of a better way to do it at this point.