### PR TITLE
Fixes broken windows compatibility since upgrade to globby@v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5341,7 +5341,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "npm": {
       "version": "6.14.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5342,7 +5342,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
     },
     "npm": {
       "version": "6.14.16",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lodash": "^4.17.21",
     "meow": "^9.0.0",
     "minimist": "^1.2.5",
+    "normalize-path": "^3.0.0",
     "semver-compare": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "test": "jest --verbose --runInBand",
     "release": "node-publisher release",
     "ci": "npm run lint && npm test",
-    "lint": "eslint 'src/**/*.js' && prettier --check 'src/**/*.js'",
-    "format": "./node_modules/.bin/prettier --write 'src/**/*.js'",
+    "lint": "eslint src/**/*.js && prettier --check src/**/*.js",
+    "format": "prettier --write src/**/*.js",
     "lint-staged": "lint-staged"
   },
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const uniq = require("lodash/uniq");
 const orderBy = require("lodash/orderBy");
 const globby = require("globby");
 const perf = require("execution-time")();
+const normalize = require("normalize-path");
 
 const runCommand = require("./utils/runCommand");
 const fileExists = require("./utils/fileExists");
@@ -86,7 +87,9 @@ module.exports = async ({ input, flags }) => {
     : packagesConfig;
 
   const packagesRead = await globby(
-    defaultPackagesGlobs.map(glob => resolve(projectDir, glob, "package.json")),
+    defaultPackagesGlobs.map(glob => {
+      return normalize(resolve(projectDir, glob, "package.json"));
+    }),
     { expandDirectories: true }
   );
 


### PR DESCRIPTION
The update of `globby` to version v11 #112 has broken the compatibility with windows.

The reason for that is a change of `globby`'s transitive dependency `fast-glob` which requires a convertion of the Windows-style path to a Unix-style path.

**Quote:** 
- https://github.com/sindresorhus/globby/issues/130#issuecomment-517438516

**Recommendation `fast-glob`:**
https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows

Based on the Recommendation, I used [`normalize-path`](https://www.npmjs.com/package/normalize-path) to ensure posix/unix-like forward slashes.

In addition I removed the single quotes from the file patterns at the `lint` and `format` script because both scripts failed with a similar message.

#### `lint`
```shell
 npm run lint

> eslint 'src/**/*.js' && prettier --check 'src/**/*.js'


Oops! Something went wrong! :(

ESLint: 8.0.1

No files matching the pattern "'src/**/*.js'" were found.
Please check for typing mistakes in the pattern.
```

####  `format`

```shell
> prettier --write 'src/**/*.js'

[error] No files matching the pattern were found: "'src/**/*.js'".
```

Closes #118 